### PR TITLE
fix duplicate GlobalObjectIdHash & not save problem

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -59,8 +59,20 @@ namespace Unity.Netcode
                 return;
             }
 
-            var globalObjectIdString = UnityEditor.GlobalObjectId.GetGlobalObjectIdSlow(this).ToString();
+            var globalObjectId = UnityEditor.GlobalObjectId.GetGlobalObjectIdSlow(this);
+            if (globalObjectId.assetGUID.Empty() && globalObjectId.identifierType == 0 &&
+                globalObjectId.targetObjectId == 0 && globalObjectId.targetPrefabId == 0)
+            {
+                return;
+            }
+
+            var lastIdHash = GlobalObjectIdHash;
+            var globalObjectIdString = globalObjectId.ToString();
             GlobalObjectIdHash = XXHash.Hash32(globalObjectIdString);
+            if (lastIdHash != GlobalObjectIdHash)
+            {
+                UnityEditor.EditorUtility.SetDirty(this.gameObject);
+            }
         }
 #endif // UNITY_EDITOR
 


### PR DESCRIPTION
Duplicate GlobalObjectIdHash come out always, globalObjectId got null in some phase like PrefabImporterEditor::OnDestroy, another problem is GlobalObjectIdHash changed but prefab don't.

<!-- Replace this block with what this PR does and why. Describe what you'd like reviewers to know, how you applied the engineering principles, and any interesting tradeoffs made. Delete bullet points below that don't apply, and update the changelog section as appropriate. -->

<!-- Add short version of the JIRA ticket to the PR title (e.g. "feat: new shiny feature [MTT-123]") -->

<!-- Add RFC link here if applicable. -->

## Changelog

- Added: The package whose Changelog should be added to should be in the header. Delete the changelog section entirely if it's not needed.
- Fixed: If you update multiple packages, create a new section with a new header for the other package. 
- Removed/Deprecated/Changed: Each bullet should be prefixed with Added, Fixed, Removed, Deprecated, or Changed to indicate where the entry should go.

## Testing and Documentation

- No tests have been added.
- Includes unit tests.
- Includes integration tests.
- No documentation changes or additions were necessary.
- Includes documentation for previously-undocumented public API entry points.
- Includes edits to existing public API documentation.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
